### PR TITLE
Fixed Semi-Standard Linter Bug

### DIFF
--- a/.github/workflows/cicd_pull_requests.yml
+++ b/.github/workflows/cicd_pull_requests.yml
@@ -21,11 +21,7 @@ jobs:
       - name: Install Semi-Standard Style
         run: npm install semistandard --global
       - name: Run Semi-Standard Styler linter
-        run: |
-          pwd
-          cd src
-          ls
-          semistandard
+        run: semistandard --env browser --env jest
   lint-html-css:
     name: Lint HTML & CSS
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd_push_to_dev.yml
+++ b/.github/workflows/cicd_push_to_dev.yml
@@ -19,11 +19,7 @@ jobs:
       - name: Install Semi-Standard Style
         run: npm install semistandard --global
       - name: Run Semi-Standard Styler linter
-        run: |
-          pwd
-          cd src
-          ls
-          semistandard
+        run: semistandard --env browser --env jest
   lint-html-css:
     name: Lint HTML & CSS
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd_push_to_main.yml
+++ b/.github/workflows/cicd_push_to_main.yml
@@ -19,11 +19,7 @@ jobs:
       - name: Install Semi-Standard Style
         run: npm install semistandard --global
       - name: Run Semi-Standard Styler linter
-        run: |
-          pwd
-          cd src
-          ls
-          semistandard
+        run: semistandard --env browser --env jest
   lint-html-css:
     name: Lint HTML & CSS
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
     "test": "jest"
   },
   "semistandard": {
-    "env": {
-        "browser": true,
-        "jest": true
-    }
+    "ignore": [
+        "dist/",
+        "docs/"
+    ]
   }
 }


### PR DESCRIPTION
Fixed issue where Semi-Standard didn't recognize environment global variables.

**Fix Details:**

- Specified environment variables when running `semistandard` via the command
```
semistandard --env browser --env jest
```
- Updated `package.json` so that Semi-Standard ignores the `dist` and `docs` directories
- With this change, **the `test` directory IS linted!** But that can easily be altered

Closes #43 

Relevant Resources:

How to configure Standard JS
https://stackoverflow.com/questions/50836791/how-to-configure-standardjs

Solution for particular issue (didn't work sadly - likely not accessible directly from Semi-Standard's config?)
https://stackoverflow.com/questions/43428994/jslint-in-brackets-says-audio-is-not-defined-but-doesnt-complain-about-image