### PR TITLE
Updated minifier step (new minimize.sh script)

### DIFF
--- a/.github/minimize.sh
+++ b/.github/minimize.sh
@@ -1,0 +1,52 @@
+#   Minifier Script
+#   IMPORTANT - this script needs permission to run! Run the command
+#   $ git update-index --chmod=+x ./.github/minimize.sh
+#   from the top directory, and push the change in a commit.
+#   This must be done for any bash script that is created or renamed
+#   on a Windows machine in order to run it in a GitHub Action.
+#   Source: https://aileenrae.co.uk/blog/github-actions-shell-script-permission-denied-error/
+
+npm install uglify-js -g
+npm install html-minifier-terser -g
+FILES="src/"
+
+#   Make subdirectories from src/ into dist/ (preserve subdirectory structure)
+find $FILES -type d ! -name "src" | while read fname
+    do
+        echo "directory: ${fname}"
+        mkdir dist/${fname#src/}
+    done
+
+#find $FILES -type f -name "*.js" -or -name "*.css" -or -name "*.html" | while read fname
+
+#   Minify javascript files in src/ using uglify-js
+find $FILES -type f -name "*.js" | while read fname
+    do
+        #echo ${fname}
+        out="$(basename ${fname})"
+        #echo $out
+        #echo ${fname#src/}
+        echo "Minimizing ${fname}..."
+        # minify ${fname} > dist/${fname}
+        #minify $out > dist/$out
+        touch dist/${fname#src/}
+        uglifyjs --compress --mangle -- ${fname} > dist/${fname#src/}
+    done
+
+#   Minify HTML and CSS files in src/ using html-minifier-terser
+find $FILES -type f -name "*.html" -or -name "*.css" | while read fname
+    do
+        echo "Minimizing ${fname}..."
+        touch dist/${fname#src/}
+        html-minifier-terser --collapse-whitespace --remove-comments --minify-js true ${fname} > dist/${fname#src/}
+    done
+
+#   Copy all other files from src/ unchanged into dist/
+find $FILES -type f ! \( -name "*.js" -or -name "*.html" -or -name "*.css" \) | while read fname
+    do
+        echo "Copying ${fname} without minimizing..."
+        cp "$fname" dist/${fname#src/}
+    done
+
+#   Copy 
+#cp -r src/assets dist

--- a/.github/workflows/cicd_push_to_main.yml
+++ b/.github/workflows/cicd_push_to_main.yml
@@ -113,43 +113,18 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
   run-minimizer:
-    name: Run Minimizer
-    #needs: [run-test-suite, create-documentation]
-    #needs: run-test-suite
-    #needs: [create-documentation, lint-html-css]
+    name: Run Minimizer v4
     needs: create-documentation
     runs-on: ubuntu-latest
-
-    permissions:
-      # Lets this job push the docs to the repository
-      contents: write
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
         with:
-            persist-credentials: false
-            fetch-depth: 0
-        # Add Minimizer Code here
-      - name: Minimize Code
-        uses: docker://devatherock/minify-js:1.0.3
-        with:
-          directory: 'src'      # Optional
-          output: 'dist'  # Optional
-          add_suffix: false     # Optional
-      - name: Commit files to dist directory
+          fetch-depth: 0
+      - name: Minify code in src/ directory
         run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git pull
-          cp -r src/assets dist
-          git add dist
-          git commit -a -m "Minimized files" --allow-empty
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+          ./.github/minimize.sh
   deploy:
     name: Deploy
     needs: run-minimizer


### PR DESCRIPTION
Updated code minifier step in the CI/CD `push to main` workflow.

Added the `minimize.sh` script to the `.github` directory to minimize files while maintaing the subdirectory structure of the `src` folder:

- JavaScript files are minimized with `uglify-js`
- HTML and CSS files are minimized with `html-minifier-terser`
- Other files (e.g., JSON, images, sound files, other assets, etc.) are copied without minification.