### PR TITLE
Disabled "tagname-lowercase" HTML linting rule

### DIFF
--- a/.htmlhintrc
+++ b/.htmlhintrc
@@ -1,0 +1,3 @@
+{
+    "tagname-lowercase": false
+}


### PR DESCRIPTION
Molybdomancy currently is only failing one HTML rule.

Unfortunately, there's no way to avoid this failure - the linter doesn't like how a particular HTML component is named. To fix this, I have added a `.htmlhintrc` config file at the top of the repository and specified to the linter to ignore the rule [`tagname-lowercase`](https://htmlhint.com/docs/user-guide/rules/tagname-lowercase).

For the moment, this closes #87 